### PR TITLE
chore: build package as part of npm prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
+    "prepare": "npm run build",
     "build": "tsc -p tsconfig.cjs.json & tsc -p tsconfig.esm.json & tsc -p tsconfig.dts.json & browserify -e src/index-browser.ts -p [ tsify ] -o dist/browser/index.js",
     "test": "jest",
     "test-watch": "jest --watchAll",


### PR DESCRIPTION
When specifying the `odata-query` package source as github, this allows the source to be built as part of the npm install steps.